### PR TITLE
A typo prevents using custom transport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ results
 
 npm-debug.log
 node_modules
+.idea

--- a/dist/ngBloodhound.js
+++ b/dist/ngBloodhound.js
@@ -191,7 +191,7 @@
                 var pendingRequestsCount = 0, pendingRequests = {}, maxPendingRequests = 6, requestCache = new LruCache(10), lastUrl = "";
                 function Transport(o) {
                     o = o || {};
-                    this._send = o.transport ? callbackToDeferred(o.transport) : $http.get;
+                    this._send = o.transport ? callbackToPromise(o.transport) : $http.get;
                     this._get = o.rateLimiter ? o.rateLimiter(this._get) : this._get;
                 }
                 Transport.setMaxPendingRequests = function setMaxPendingRequests(num) {

--- a/src/transport.js
+++ b/src/transport.js
@@ -23,7 +23,7 @@
       function Transport(o) {
         o = o || {};
 
-        this._send = o.transport ? callbackToDeferred(o.transport) : $http.get;
+        this._send = o.transport ? callbackToPromise(o.transport) : $http.get;
         this._get = o.rateLimiter ? o.rateLimiter(this._get) : this._get;
       }
 


### PR DESCRIPTION
function callbackToPromise(fn) {...} is invoked as as callbackToDeferred(o.transport) 
